### PR TITLE
Handle remote branch renames

### DIFF
--- a/src/bin/subup.rs
+++ b/src/bin/subup.rs
@@ -176,7 +176,7 @@ impl<'a> SubUp<'a> {
             let original_hash = self.get_hash(&format!("HEAD:{}", path), ".")?;
             let submodule = Submodule {
                 path: path.to_string(),
-                rev: "master".to_string(), // Will set below.
+                rev: "HEAD".to_string(), // Will set below.
                 wants_update: false,       // Will set below.
                 was_updated: false,
                 original_hash,
@@ -202,9 +202,7 @@ impl<'a> SubUp<'a> {
                     }
                     (parts[0].to_string(), rev.unwrap())
                 } else {
-                    // TODO: This probably shouldn't assume master, but the
-                    // value in .gitmodules may not be accurate.
-                    (parts[0].to_string(), "master".to_string())
+                    (parts[0].to_string(), "HEAD".to_string())
                 }
             } else {
                 (parts[1].to_string(), parts[0].to_string())
@@ -230,6 +228,11 @@ impl<'a> SubUp<'a> {
                 .git("fetch --tags")
                 .dir(&submodule.path)
                 .run(format!("Failed to fetch in module `{}`.", submodule.path))?;
+
+            self.cli
+                .git("remote set-head origin -a")
+                .dir(&submodule.path)
+                .run(format!("Failed to set-head in module `{}`.", submodule.path))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Hey, sooo I wanted to try to fix this to handle the book and other submodules changing their default branch names.

I added a call to `git remote set-head origin -a`, which should get what a submodule's default branch is. Then by using `HEAD` instead of `master`, this should Just Work™. I tested this... sorta... but not with rust-lang/rust, so while testing, I had other parts of the code commented out... 

The only downside with this that I can see is that it leaves the submodule in detached HEAD state... is that ok? I *think* there's some way with `git symbolic-ref` or something to get the actual branch name that `origin/HEAD` is pointing to and checking that out instead, and I can look into that if that's desired. But I figured the submodules are set to a particular commit anyway, so maybe it doesn't matter.

